### PR TITLE
adding option for delimiters to the graphite metrics plugin

### DIFF
--- a/artdaq-utilities/Plugins/fcl/graphite_metric.fcl
+++ b/artdaq-utilities/Plugins/fcl/graphite_metric.fcl
@@ -24,4 +24,5 @@ daq.metrics.graphite: { # Can be named anything.
   port: 2003           # The port number for metric data
   namespace: "artdaq." # The Graphite "namespace" for the metrics used. Namespaces are used for
                        # organizing metrics, and may be hierarchical, e.g., artdaq.evb., artdaq.br., etc.
+  #defaults: [":"]     # list of delimiters that are replaced by "." (the graphite delimiter) in the metrics name sent to graphite
 }

--- a/artdaq-utilities/Plugins/graphite_metric.cc
+++ b/artdaq-utilities/Plugins/graphite_metric.cc
@@ -37,6 +37,7 @@ private:
 	std::string host_;
 	int port_;
 	std::string namespace_;
+	std::vector<std::string> delimiters_;
 	boost::asio::io_service io_service_;
 	tcp::socket socket_;
 	bool stopped_;
@@ -49,6 +50,7 @@ public:
 	 * \param config ParameterSet used to configure GraphiteMetric
 	 * \param app_name Name of the application sending metrics
 	 * \param metric_name Name of this MetricPlugin instance
+	 * \param delimiters List of metri name delimiters that will be replaced by "." for graphite
 	 *
 	 * \verbatim
 	 * GraphiteMetric accepts the following Parameters:
@@ -62,6 +64,7 @@ public:
 	    , host_(pset.get<std::string>("host", "localhost"))
 	    , port_(pset.get<int>("port", 2003))
 	    , namespace_(pset.get<std::string>("namespace", "artdaq."))
+		, delimiters_(pset.get<std::vector<std::string>>("delimiters", std::vector<std::string>()))
 	    , io_service_()
 	    , socket_(io_service_)
 	    , stopped_(true)
@@ -95,6 +98,9 @@ public:
 			boost::asio::streambuf data;
 			auto nameTemp(name);
 			std::replace(nameTemp.begin(), nameTemp.end(), ' ', '_');
+			for (auto delimiter : delimiters_) {
+				std::replace(nameTemp.begin(), nameTemp.end(), delimiter[0], '.');
+            }
 			std::ostream out(&data);
 			out << namespace_ << nameTemp << " "
 			    << value << " "

--- a/artdaq-utilities/Plugins/graphite_metric.cc
+++ b/artdaq-utilities/Plugins/graphite_metric.cc
@@ -50,7 +50,7 @@ public:
 	 * \param config ParameterSet used to configure GraphiteMetric
 	 * \param app_name Name of the application sending metrics
 	 * \param metric_name Name of this MetricPlugin instance
-	 * \param delimiters List of metri name delimiters that will be replaced by "." for graphite
+	 * \param delimiters List of delimiters that will be replaced by "." (the Graphite field delimeter) in metric names
 	 *
 	 * \verbatim
 	 * GraphiteMetric accepts the following Parameters:
@@ -64,7 +64,7 @@ public:
 	    , host_(pset.get<std::string>("host", "localhost"))
 	    , port_(pset.get<int>("port", 2003))
 	    , namespace_(pset.get<std::string>("namespace", "artdaq."))
-		, delimiters_(pset.get<std::vector<std::string>>("delimiters", std::vector<std::string>()))
+	    , delimiters_(pset.get<std::vector<std::string>>("delimiters", std::vector<std::string>()))
 	    , io_service_()
 	    , socket_(io_service_)
 	    , stopped_(true)
@@ -98,9 +98,11 @@ public:
 			boost::asio::streambuf data;
 			auto nameTemp(name);
 			std::replace(nameTemp.begin(), nameTemp.end(), ' ', '_');
-			for (auto delimiter : delimiters_) {
+			for (auto delimiter : delimiters_)
+			{
+				if (delimeter == "") continue;
 				std::replace(nameTemp.begin(), nameTemp.end(), delimiter[0], '.');
-            }
+			}
 			std::ostream out(&data);
 			out << namespace_ << nameTemp << " "
 			    << value << " "

--- a/artdaq-utilities/Plugins/graphite_metric.cc
+++ b/artdaq-utilities/Plugins/graphite_metric.cc
@@ -100,7 +100,7 @@ public:
 			std::replace(nameTemp.begin(), nameTemp.end(), ' ', '_');
 			for (auto delimiter : delimiters_)
 			{
-				if (delimeter == "") continue;
+				if (delimiter == "") continue;
 				std::replace(nameTemp.begin(), nameTemp.end(), delimiter[0], '.');
 			}
 			std::ostream out(&data);


### PR DESCRIPTION
This addition is motivated by otsdaq slow control channels which have the form DTC:channe_name (which is needed for epics). This option allows us to change it to DTC.channel_name, which in turn allows for better representation in graphite/grafana 